### PR TITLE
Implement schema importer

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,16 @@ you can define it yourself if you like, or use dataclasses for everything (which
 </table>
 
 
+# Import an existing schema
+
+If you already have a GraphQL schema you want to work with, it's easy to get started with Graphotype. Simply install the package, then do
+
+```bash
+python -m graphotype import [schema_file]
+```
+
+This works with either .graphql schema format or a JSON introspection-query result, and outputs a Python file for you. 
+See the `--help` of that command for more info.
 
 
 # Development on Graphotype itself

--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ you can define it yourself if you like, or use dataclasses for everything (which
 
 # Import an existing schema
 
-If you already have a GraphQL schema you want to work with, it's easy to get started with Graphotype. Simply install the package, then do
+If you already have a GraphQL schema you want to work with, it's easy to get started with Graphotype. 
+After installing graphotype, you also need to `pip install jinja2 black`, then do
 
 ```bash
 python -m graphotype import [schema_file]

--- a/graphotype/__main__.py
+++ b/graphotype/__main__.py
@@ -1,11 +1,10 @@
-from typing import List
-from typing import IO
+from typing import IO, List
 
 import argparse
 import importlib
-import os
 
-from graphql import GraphQLSchema, graphql
+from graphql import GraphQLSchema, graphql, build_ast_schema, parse as gql_parse
+from graphql.error.syntax_error import GraphQLSyntaxError
 from graphql.utils.schema_printer import print_schema
 from graphql.utils.introspection_query import introspection_query
 
@@ -47,11 +46,54 @@ def serve(schema: GraphQLSchema, port: int) -> None:
     ))
     app.run(port=port)
 
+
+def import_schema(input_schema: IO[str], output: IO[str]) -> None:
+    """Import an existing json or graphql schema file, outputting a matching stub Graphotype file.
+
+    If it's a json file, the correct format is: {"data": {"__schema": ...}}
+    If a graphql file, the correct format is:   schema { query: ... }
+
+    The output Python code is compatible with python 3.7. Unknown scalar and enum types
+    will appear in the output unchanged.
+    """
+    try:
+        import jinja2
+        import black
+    except ImportError:
+        raise ImportError('jinja2 and black must be installed')
+
+    import json
+
+    source = input_schema.read()
+    try:
+        js_ast = json.loads(source)['data']
+    except (json.JSONDecodeError, KeyError) :
+        # let's try schema parsing
+        try:
+            gql_ast_schema = build_ast_schema(gql_parse(source))
+            js_ast = graphql(gql_ast_schema, introspection_query).data
+        except GraphQLSyntaxError as e:
+            # Ok, that didn't work either -- throw it back to the user
+            raise Exception("Please specify a valid JSON introspection or GraphQL schema file to import") from e
+
+    from . import import_schema
+    result = import_schema.process(js_ast)
+
+    try:
+        result = black.format_file_contents(result, line_length=80, fast=False)
+    except black.NothingChanged:
+        # this is ok, though surprising
+        pass
+
+    output.write(result)
+
+
 def main(argv: List[str]) -> None:
     parser = argparse.ArgumentParser(
         description="Manipulate graphotype schemas."
     )
     subparsers = parser.add_subparsers(title='command')
+
     # dump command
     dump_parser = subparsers.add_parser('dump', help='Write schema to a file')
     _add_schema_obj(dump_parser)
@@ -73,11 +115,22 @@ def main(argv: List[str]) -> None:
         help='Pretty-print JSON output'
     )
     dump_parser.set_defaults(func=dump)
+
     # serve
     serve_parser = subparsers.add_parser('serve', help='Start a local GQL server')
     _add_schema_obj(serve_parser)
     serve_parser.add_argument('-p', '--port', type=int, default=8123)
     serve_parser.set_defaults(func=serve)
+
+    # import
+    import_parser = subparsers.add_parser('import', help='Import existing GQL schema and convert to Graphotype Python code')
+    import_parser.add_argument(
+        'input_schema',
+        type=argparse.FileType('r'),
+        help="The input schema (in graphql schema or json format)"
+    )
+    import_parser.add_argument('-o', '--output', type=argparse.FileType('w'), default=sys.stdout)
+    import_parser.set_defaults(func=import_schema)
 
     parsed = parser.parse_args(argv)
     params = vars(parsed)

--- a/graphotype/__main__.py
+++ b/graphotype/__main__.py
@@ -63,7 +63,9 @@ def import_schema(
     If a graphql file, the correct format is:   schema { query: ... }
 
     The output Python code is compatible with python 3.7. Unknown scalar and enum types
-    will appear in the output unchanged.
+    will appear in the output unchanged by default. You can rename them with
+       -r InputName=OutputName
+    on the command line.
     """
     try:
         import jinja2

--- a/graphotype/import_schema/__init__.py
+++ b/graphotype/import_schema/__init__.py
@@ -1,0 +1,2 @@
+
+from .process import process

--- a/graphotype/import_schema/process.py
+++ b/graphotype/import_schema/process.py
@@ -1,22 +1,22 @@
-from typing import IO, Any
+from typing import IO, Any, Mapping
 import pathlib
 
 import jinja2
 
+from .template_filters import TemplateFilters
 from .schema_types import SchemaType
-from . import template_filters
 
 import_schema_folder = pathlib.Path(__file__).parent
 
-env = jinja2.Environment(
-    loader=jinja2.FileSystemLoader(str(import_schema_folder / 'templates'))
-)
 
-env.filters['pytype'] = template_filters.pytype
-
-
-def process(json_schema: Any) -> str:
+def process(json_schema: Any, renames: Mapping[str, str] = {}) -> str:
     """Consume json_schema and produce rendered python file in Graphotype format"""
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(str(import_schema_folder / 'templates'))
+    )
+
+    env.filters['pytype'] = TemplateFilters(renames).pytype
+
     schema = json_schema["__schema"]
 
     topoffile = env.get_template("top_of_file.py.tmpl")

--- a/graphotype/import_schema/process.py
+++ b/graphotype/import_schema/process.py
@@ -1,0 +1,51 @@
+from typing import IO, Any
+import pathlib
+
+import jinja2
+
+from .schema_types import SchemaType
+from . import template_filters
+
+import_schema_folder = pathlib.Path(__file__).parent
+
+env = jinja2.Environment(
+    loader=jinja2.FileSystemLoader(str(import_schema_folder / 'templates'))
+)
+
+env.filters['pytype'] = template_filters.pytype
+
+
+def process(json_schema: Any) -> str:
+    """Consume json_schema and produce rendered python file in Graphotype format"""
+    schema = json_schema["__schema"]
+
+    topoffile = env.get_template("top_of_file.py.tmpl")
+    out = topoffile.render()
+
+    t: SchemaType
+    for t in schema['types']:
+
+        if t['name'].startswith('__'):
+            # skip internal types
+            continue
+
+        kind = t['kind']
+
+        if kind == 'OBJECT':
+            tmpl = env.get_template("object_type.py.tmpl")
+            out += tmpl.render(t=t)
+
+        elif kind == 'INPUT_OBJECT':
+            tmpl = env.get_template("input_object_type.py.tmpl")
+            out += tmpl.render(t=t)
+
+        elif kind == 'INTERFACE':
+            tmpl = env.get_template("interface_type.py.tmpl")
+            out += tmpl.render(t=t)
+
+        elif kind == 'UNION':
+            tmpl = env.get_template("union_type.py.tmpl")
+            out += tmpl.render(t=t)
+
+    return out
+

--- a/graphotype/import_schema/process.py
+++ b/graphotype/import_schema/process.py
@@ -14,8 +14,10 @@ def process(json_schema: Any, renames: Mapping[str, str] = {}) -> str:
     env = jinja2.Environment(
         loader=jinja2.FileSystemLoader(str(import_schema_folder / 'templates'))
     )
+    filters = TemplateFilters(renames)
 
-    env.filters['pytype'] = TemplateFilters(renames).pytype
+    env.filters['pytype'] = filters.pytype
+    env.filters['quoted'] = filters.quoted
 
     schema = json_schema["__schema"]
 

--- a/graphotype/import_schema/schema_types.py
+++ b/graphotype/import_schema/schema_types.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Optional, List
+
+from mypy_extensions import TypedDict
+
+TypeRef = TypedDict('TypeRef',
+                    {
+                        'kind': str,  # NON_NULL / LIST / SCALAR
+                        'name': Optional[str],
+                        'ofType': Optional['TypeRef']
+                    })
+
+Field = TypedDict('Field',
+                  {
+                      'name': str,
+                      'description': Optional[str],
+                      'args': List['Argument'],
+                      'type': TypeRef,
+                      'isDeprecated': bool,
+                      'deprecationReason': Optional[str],
+                  })
+
+Arg = TypedDict('Arg',
+                {
+                    'name': str,
+                    'description': Optional[str],
+                    'type': TypeRef,
+                    'defaultValue': Optional[str],  # This is a gql literal (!) i think
+                })
+
+SchemaType = TypedDict('SchemaType',
+                       {
+                           'kind': str,
+                           'name': str,
+                           'description': Optional[str],
+                           'fields': Optional[List[Field]],
+                           'inputFields': Optional[List[Arg]],
+                           'interfaces': Optional[List['x']],
+                           'enumValues': Optional[List['y']],
+                           'possibleTypes': Optional[List[TypeRef]],
+                       })

--- a/graphotype/import_schema/schema_types.py
+++ b/graphotype/import_schema/schema_types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional, List
+from typing import Optional, List, Any
 
 from mypy_extensions import TypedDict
 
@@ -36,7 +36,7 @@ SchemaType = TypedDict('SchemaType',
                            'description': Optional[str],
                            'fields': Optional[List[Field]],
                            'inputFields': Optional[List[Arg]],
-                           'interfaces': Optional[List['x']],
-                           'enumValues': Optional[List['y']],
+                           'interfaces': Optional[List[TypeRef]],
+                           'enumValues': Optional[List[Any]],   # Not used
                            'possibleTypes': Optional[List[TypeRef]],
                        })

--- a/graphotype/import_schema/template_filters.py
+++ b/graphotype/import_schema/template_filters.py
@@ -1,0 +1,35 @@
+from typing import Mapping
+
+from .schema_types import TypeRef
+
+# Types that have different Python names than their GQL names
+pytype_mapping: Mapping[str, str] = {
+    'Int': 'int',
+    'String': 'str',
+    'Boolean': 'bool',
+    'Float': 'float',
+    'Bytes': 'bytes',
+}
+
+def pytype(t: TypeRef, nonnull=False) -> str:
+    """Render a TypeRef into a string"""
+
+    if t["kind"] == 'NON_NULL':
+        # Unwrap the nonnull
+        return pytype(t["ofType"], nonnull=True)
+
+    if t["kind"] == 'LIST':
+        # Wrap 'List[]' around the recursive
+        inner = pytype(t["ofType"], nonnull=True)
+        return f'List[{inner}]'
+
+    name = t["name"]
+    if name in pytype_mapping:
+        mapped = pytype_mapping[name]
+    else:
+        mapped = name
+
+    if not nonnull:
+        mapped = f'Optional[{mapped}]'
+
+    return mapped

--- a/graphotype/import_schema/template_filters.py
+++ b/graphotype/import_schema/template_filters.py
@@ -37,3 +37,7 @@ class TemplateFilters:
             mapped = f'Optional[{mapped}]'
 
         return mapped
+
+    def quoted(self, s: str) -> str:
+        """Return a quoted s (for Python source code)"""
+        return repr(s)

--- a/graphotype/import_schema/templates/input_object_type.py.tmpl
+++ b/graphotype/import_schema/templates/input_object_type.py.tmpl
@@ -1,0 +1,12 @@
+# Input object
+@dataclass(frozen=True)
+class {{ t.name }}:
+    {%- for a in t.inputFields %}
+    {{ a.name }}: {{ a.type|pytype }}
+    {%- if a.default_value -%}
+    # = {{ a.default_value }}
+    {%- endif -%}
+    {% endfor %}
+
+
+

--- a/graphotype/import_schema/templates/interface_type.py.tmpl
+++ b/graphotype/import_schema/templates/interface_type.py.tmpl
@@ -1,0 +1,2 @@
+class {{ t.name }}(Interface): pass
+

--- a/graphotype/import_schema/templates/object_type.py.tmpl
+++ b/graphotype/import_schema/templates/object_type.py.tmpl
@@ -1,0 +1,20 @@
+
+@dataclass(frozen=True)
+class {{ t.name }}(Object):
+    {%- for f in t.fields %}
+    {%- if f.args or t.name == 'Query' or t.name == 'Mutation' %}
+    def {{f.name}}(self
+        {% for a in f.args %}
+        ,{{ a.name }}: {{ a.type|pytype }}
+        {%- if a.default_value -%}
+        # = {{ a.default_value }}
+        {%- endif -%}
+
+        {% endfor %}
+    ) -> {{ f.type|pytype }}: ...
+    {%- else %}
+    {{f.name}}: {{ f.type|pytype }}
+    {%- endif %}
+    {%- endfor %}
+
+

--- a/graphotype/import_schema/templates/object_type.py.tmpl
+++ b/graphotype/import_schema/templates/object_type.py.tmpl
@@ -1,6 +1,10 @@
 
 @dataclass(frozen=True)
-class {{ t.name }}(Object):
+class {{ t.name }}(Object
+{%- for sc in t.interfaces %}
+, {{ sc|pytype(nonnull=True) }}
+{%- endfor %}
+):
     {%- for f in t.fields %}
     {%- if f.args or t.name == 'Query' or t.name == 'Mutation' %}
     def {{f.name}}(self

--- a/graphotype/import_schema/templates/query.py.tmpl
+++ b/graphotype/import_schema/templates/query.py.tmpl
@@ -1,0 +1,4 @@
+class Query(Object):
+    {% for f in t.fields %}
+    def {{ f.name }}(
+    ):

--- a/graphotype/import_schema/templates/top_of_file.py.tmpl
+++ b/graphotype/import_schema/templates/top_of_file.py.tmpl
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional, List, Union
+

--- a/graphotype/import_schema/templates/top_of_file.py.tmpl
+++ b/graphotype/import_schema/templates/top_of_file.py.tmpl
@@ -3,3 +3,5 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Optional, List, Union
 
+from graphotype import ID, Object, Interface
+

--- a/graphotype/import_schema/templates/union_type.py.tmpl
+++ b/graphotype/import_schema/templates/union_type.py.tmpl
@@ -1,5 +1,5 @@
 {{ t.name }} = Union[
     {%- for pt in t.possibleTypes %}
-    {{ pt|pytype }},
+    {{ pt|pytype(nonnull=True)|quoted }},
     {%- endfor %}
 ]

--- a/graphotype/import_schema/templates/union_type.py.tmpl
+++ b/graphotype/import_schema/templates/union_type.py.tmpl
@@ -1,0 +1,5 @@
+{{ t.name }} = Union[
+    {%- for pt in t.possibleTypes %}
+    {{ pt|pytype }},
+    {%- endfor %}
+]

--- a/test.py
+++ b/test.py
@@ -72,7 +72,7 @@ class Date(graphotype.Scalar):
 
 MyUnion = Union[Foo, Bar]
 
-schema = graphotype.make_schema(query=Query, mutation=None, scalars=[Date], unions=dict(MyUnion=MyUnion))
+schema = graphotype.make_schema(query=Query, mutation=None, scalars=[Date])
 
 if __name__ == '__main__':
     print(graphql.print_schema(schema))


### PR DESCRIPTION
This consumes a GraphQL schema (in .schema or json introspection-schema result form) 
and outputs Python code in Graphotype format -- this should make a good starting point 
for implementing that schema using Graphotype.

I think this is mergeable, but the pep563 issue where get_type_hints returns ForwardRefs is occurring frequently with the generated code, and so we may want to work around that (probably in a separate issue).