### PR TITLE
Better treatment of raw string type annotations:

### DIFF
--- a/graphotype/__init__.py
+++ b/graphotype/__init__.py
@@ -30,6 +30,7 @@ from graphql import (
 from graphql.type.definition import GraphQLNamedType
 from graphql.language import ast
 
+from graphotype.types import AnnotationOrigin
 from . import types
 
 class SchemaError(Exception):
@@ -244,7 +245,7 @@ class SchemaCreator:
                     # explicitly annotated assignment; will be handled below
                     continue
                 guessed_type = type(value)
-                fields[name] = self.attribute_field(name, types.AClass(None, guessed_type, origin=None))
+                fields[name] = self.attribute_field(name, types.AClass(None, guessed_type, origin=AnnotationOrigin(repr(cls), name)))
 
         for name, typ in hints.items():
             if name.startswith('_'):
@@ -256,7 +257,7 @@ class SchemaCreator:
         fields = {}
         for field in dataclasses.fields(cls):
             fields[field.name] = GraphQLInputObjectField(
-                type=self.translate_type(types.make_annotation(None, field.type, origin=None))
+                type=self.translate_type(types.make_annotation(None, field.type, origin=AnnotationOrigin(repr(cls), field.name)))
             )
         return fields
 

--- a/graphotype/__init__.py
+++ b/graphotype/__init__.py
@@ -324,9 +324,9 @@ class SchemaCreator:
         from graphql.utils.assert_valid_name import COMPILED_NAME_PATTERN
         if name is None or not isinstance(name, str) or not COMPILED_NAME_PATTERN.match(name):
             args = [of_t.t for of_t in ann.of_types]
+            defined_at = "Defined at {ann.origin.classname}.{ann.origin.fieldname}.\n" if ann.origin else ""
             raise SchemaError(f"""Could not find a name for Union{args}.
-Defined at {ann.origin.classname}.{ann.origin.fieldname}.
-
+{defined_at} 
 In GraphQL, any union needs a name, so all unions must be
 forward-referenced, e.g.:
     Person = Union[Manager, Employee]

--- a/graphotype/__init__.py
+++ b/graphotype/__init__.py
@@ -318,7 +318,9 @@ class SchemaCreator:
     def map_union(self, ann: types.AUnion) -> GraphQLUnionType:
         args = [of_t.t for of_t in ann.of_types]
         name = ann.name
-        if name is None:
+
+        from graphql.utils.assert_valid_name import COMPILED_NAME_PATTERN
+        if name is None or not isinstance(name, str) or not COMPILED_NAME_PATTERN.match(name):
             raise SchemaError(f"""Could not find a name for Union[{args}].
 
 In GraphQL, any union needs a name, so all unions must be

--- a/graphotype/types.py
+++ b/graphotype/types.py
@@ -1,7 +1,14 @@
 from typing import Type, NamedTuple, List, Iterable, Iterator, Optional, Any, Dict, get_type_hints, Union
 
+try:
+    from typing import ForwardRef
+except ImportError:
+    # python 3.6 I guess?
+    class ForwardRef: pass
+
 from dataclasses import dataclass
 import typing_inspect
+from graphql.utils.assert_valid_name import COMPILED_NAME_PATTERN
 
 NoneType = type(None)
 
@@ -15,18 +22,24 @@ class Annotation:
 
 @dataclass
 class AUnion(Annotation):
+    """Union[x, y, ...] that is not an Optional"""
     of_types: List[Annotation]
 
 @dataclass
 class AList(Annotation):
+    """List[x]"""
     of_type: Annotation
 
 @dataclass
 class AOptional(Annotation):
+    """Optional[x]"""
     of_type: Annotation
 
 @dataclass
 class ANewType(Annotation):
+    """NewType of another Annotation.
+
+    This uses the same python implementation with a different GraphQL type."""
     of_type: Annotation
     @property
     def typename(self):
@@ -34,6 +47,7 @@ class ANewType(Annotation):
 
 @dataclass
 class AClass(Annotation):
+    """Everything else (Python class -- this can be scalars and object types)"""
     @property
     def typename(self):
         return self.t.__name__
@@ -58,24 +72,41 @@ def _get_iterable_of(t: Type) -> Optional[Type]:
     return None
 
 def make_annotation(raw: Optional[Any], parsed: Type) -> Annotation:
+    """Recursively transform a Python type hint into an Annotation for our schema.
+
+    'parsed' should be a result of typing.get_type_hints on something.
+    'raw', if available, should be the string annotation from __annotations__.
+
+    This is recursive because a type like Union or List references other types.
+    """
     if typing_inspect.is_union_type(parsed):
         args = typing_inspect.get_args(parsed, evaluate=True)
+        # If is_optional is true, wrap the union in an Optional at the end.
         is_optional = NoneType in args
+
         args = [arg for arg in args if arg != NoneType]
-        # special case to ensure Optional['foo'].of_type.name == 'foo' etc.
-        if typing_inspect.is_union_type(raw):
-            raw_args = typing_inspect.get_args(raw)
-            of_types = [
-                make_annotation(t_raw, t)
-                for t_raw, t in zip(raw_args, args)
-            ]
+
+        # Try and unwrap the outermost thing in `raw` because it may be useful later. If we fail, that's ok,
+        # we can fallback to None.
+        unwrapped_raw = _unwrap_outer_nullable(raw)
+
+        if len(args) == 1:
+            raw_args = [unwrapped_raw]
         else:
-            of_types = [make_annotation(None, t) for t in args]
+            raw_args = [None] * len(args)
+
+        of_types = [
+            make_annotation(t_raw, t)
+            for t_raw, t in zip(raw_args, args)
+        ]
+
         if len(of_types) == 1:
             [ann] = of_types
         else:
             ann = AUnion(
-                t_raw=None if is_optional else raw,
+                # interpret 'is_optional' being true as meaning we should use the unwrapped raw
+                # this enables Optional[MyUnion] to work
+                t_raw=unwrapped_raw if is_optional else raw,
                 t=Union[tuple(args)],
                 of_types=of_types
             )
@@ -96,7 +127,7 @@ def make_annotation(raw: Optional[Any], parsed: Type) -> Annotation:
         return AList(
             t_raw=raw,
             t=parsed,
-            of_type=make_annotation(None, iter_of)
+            of_type=make_annotation(_unwrap_outer_nullable(raw), iter_of)
         )
     if isinstance(parsed, type):
         return AClass(
@@ -106,8 +137,70 @@ def make_annotation(raw: Optional[Any], parsed: Type) -> Annotation:
     raise ValueError(f"Don't understand type {parsed}")
 
 
+class UnwrapException(Exception): pass
+
+
+def _unwrap_outer_str(raw: str) -> str:
+    """Parse and unwrap the outermost type and 1 layer of brackets from `raw`,
+     returning whatever is inside the outermost brackets.
+     """
+
+    import re
+    result = re.match(r'^\s*[_a-zA-Z][_a-zA-Z0-9]*\s*\[(.+)\]\s*$', raw, re.DOTALL)
+    if not result:
+        raise UnwrapException(f"unable to match unwrap pattern: {repr(raw)}")
+
+    return result.group(1).strip()
+
+
+def _unwrap_outer(raw: Any) -> Any:
+    """Unwrap one layer of type wrapper from 'raw', which is the raw
+    annotation value from __annotations__ (which should only be a String,
+    or either an Optional or List).
+
+    If `raw` is a string, we use unwrap_outer_str.
+
+    If we fail, raises UnwrapException
+    """
+    if isinstance(raw, str):
+        # If given 'Optional[foo]', give back 'foo'.
+        return _unwrap_outer_str(raw)
+
+    if typing_inspect.is_union_type(raw):
+        # If given Optional['foo'], give back 'foo'.
+        # If given Optional[foo], give back foo.
+        # If given Union[int, str], throw.
+        raw_args = [x for x in typing_inspect.get_args(raw) if x is not NoneType]
+        if len(raw_args) != 1:
+            raise UnwrapException(f"Unwrap_outer ran into a Union: {raw}")
+
+    else:
+        raw_args = typing_inspect.get_args(raw)
+
+    if len(raw_args) != 1:
+        raise UnwrapException(f"Unwrap_outer doesn't know what to do with {len(raw_args)}-arg type: {raw}")
+
+    arg = raw_args[0]
+
+    if isinstance(arg, ForwardRef):
+        # In python3.7, we (might) sometimes get ForwardRefs in here. Unwrap to get the name in that case
+        return arg.__forward_arg__
+    else:
+        return arg
+
+
+def _unwrap_outer_nullable(raw: Any) -> Any:
+    """Same as _unwrap_outer, but catch UnwrapException and return None."""
+    try:
+        return _unwrap_outer(raw)
+    except UnwrapException:
+        return None
+
 
 def get_annotations(o: Any) -> Dict[str, Annotation]:
+    """Call get_type_hints on 'o', wrapping the resulting annotations.
+
+    The resulting hints are wrapped in our own Annotation instances."""
     ret = {}
     for k, t in get_type_hints(o).items():
         t_raw = o.__annotations__.get(k)

--- a/graphotype/types.py
+++ b/graphotype/types.py
@@ -1,4 +1,4 @@
-from typing import Type, NamedTuple, List, Iterable, Iterator, Optional, Any, Dict, get_type_hints, Union
+from typing import Type, List, Iterable, Iterator, Optional, Any, Dict, get_type_hints, Union
 
 try:
     from typing import ForwardRef
@@ -8,7 +8,6 @@ except ImportError:
 
 from dataclasses import dataclass
 import typing_inspect
-from graphql.utils.assert_valid_name import COMPILED_NAME_PATTERN
 
 NoneType = type(None)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-graphql-core
+graphql-core>=2.1
 dataclasses; python_version == '3.6'
 typing-inspect

--- a/test.py
+++ b/test.py
@@ -72,7 +72,7 @@ class Date(graphotype.Scalar):
 
 MyUnion = Union[Foo, Bar]
 
-schema = graphotype.make_schema(query=Query, mutation=None, scalars=[Date], unions=dict(MyUnion=MyUnion))
+schema = graphotype.make_schema(query=Query, mutation=None, scalars=[Date])
 
 if __name__ == '__main__':
     print(graphql.print_schema(schema))

--- a/tests/starwars/test_query.py
+++ b/tests/starwars/test_query.py
@@ -122,7 +122,7 @@ def test_fetch_some_id_query(schema):
     """
     params = {"someId": "1000"}
     expected = {"human": {"name": "Luke Skywalker"}}
-    result = graphql(schema, query, variable_values=params)
+    result = graphql(schema, query, variables=params)
     assert not result.errors
     assert result.data == expected
 
@@ -137,7 +137,7 @@ def test_fetch_some_id_query2(schema):
     """
     params = {"someId": "1002"}
     expected = {"human": {"name": "Han Solo"}}
-    result = graphql(schema, query, variable_values=params)
+    result = graphql(schema, query, variables=params)
     assert not result.errors
     assert result.data == expected
 
@@ -152,7 +152,7 @@ def test_invalid_id_query(schema):
     """
     params = {"id": "not a valid id"}
     expected = {"human": None}
-    result = graphql(schema, query, variable_values=params)
+    result = graphql(schema, query, variables=params)
     assert not result.errors
     assert result.data == expected
 

--- a/tests/test_custom_scalars.py
+++ b/tests/test_custom_scalars.py
@@ -91,7 +91,7 @@ def test_custom_scalar_from_ast(schema):
 def test_custom_scalar_from_values(schema):
     result = graphql(schema, '''query Q($f: FakeInt!, $dt: DateTime!) {
         add(f: $f, dt: $dt)
-    }''', variable_values=dict(f=1, dt=_DATETIME_STR), root=Query())
+    }''', variables=dict(f=1, dt=_DATETIME_STR), root=Query())
     assert not result.errors
     assert result.data == { 'add': 1547163308 }
 

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -38,7 +38,7 @@ def test_enum_arg_var(schema):
         schema,
         'query Q ($e: MyEnum!) { f(val: $e) }',
         root=Query(),
-        variable_values={'e': 'TWO'}
+        variables={'e': 'TWO'}
     )
     assert not result.errors
     assert result.data == {

--- a/tests/test_make_annotation.py
+++ b/tests/test_make_annotation.py
@@ -1,0 +1,86 @@
+from typing import Optional, Union, List
+
+from graphotype.types import make_annotation, AClass, AOptional, NoneType, AUnion, AList
+
+
+def test_make_annotation_simple():
+    assert make_annotation(None, str) == AClass(None, str)
+    assert make_annotation(None, Optional[int]) == AOptional(
+        None, Union[int, NoneType], of_type=AClass(None, int)
+    )
+
+
+def test_make_annotation_simple_named():
+    assert make_annotation("str", str) == AClass("str", str)
+    assert make_annotation("MaybeInt", Optional[int]) == AOptional(
+        "MaybeInt", Union[int, NoneType], of_type=AClass(None, int)
+    )
+
+
+def test_make_annotation_unwraps_optional_and_list():
+    """make_annotation will unwrap the brackets and preserve the 'raw' of whatever is inside
+    your Optionals and Lists"""
+    assert make_annotation("Optional[int]", Optional[int]) == AOptional(
+        "Optional[int]", Union[int, NoneType], of_type=AClass("int", int)
+    )
+    assert make_annotation("List[int]", List[int]) == AList(
+        "List[int]", List[int], of_type=AClass("int", int)
+    )
+    assert make_annotation("Optional[List[int]]", Optional[List[int]]) == AOptional(
+        "Optional[List[int]]",
+        Union[List[int], NoneType],
+        of_type=AList("List[int]", List[int], of_type=AClass("int", int)),
+    )
+
+
+def test_make_annotation_union():
+    """You can always call make_annotation on a Union, even though you
+    might not be able to use it directly in a graphql type."""
+    assert make_annotation(None, Union[str, int]) == AUnion(
+        None, Union[str, int], of_types=[AClass(None, str), AClass(None, int)]
+    )
+
+
+def test_make_annotation_union_named():
+    """The union name is preserved at the top level."""
+    assert make_annotation("StrOrInt", Union[str, int]) == AUnion(
+        "StrOrInt", Union[str, int], of_types=[AClass(None, str), AClass(None, int)]
+    )
+
+
+def test_make_annotation_opt_union():
+    """make_annotation on unnamed optional Union works too"""
+    assert make_annotation(None, Optional[Union[str, int]]) == AOptional(
+        None,
+        Optional[Union[str, int]],
+        of_type=AUnion(
+            None, Union[str, int], of_types=[AClass(None, str), AClass(None, int)]
+        ),
+    )
+
+
+def test_make_annotation_opt_union_named():
+    """make_annotation on optional named Union"""
+    assert make_annotation('Optional[StrOrInt]', Optional[Union[str, int]]) == AOptional(
+        'Optional[StrOrInt]',
+        Optional[Union[str, int]],
+        of_type=AUnion(
+            'StrOrInt', Union[str, int], of_types=[AClass(None, str), AClass(None, int)]
+        ),
+    )
+
+
+
+def test_make_annotation_list_union_named():
+    """make_annotation on a list of named Union"""
+    assert make_annotation("List[StrOrInt]", List[Union[str, int]]) == (
+        AList(
+            "List[StrOrInt]",
+            List[Union[str, int]],
+            of_type=AUnion(
+                "StrOrInt",
+                Union[str, int],
+                of_types=[AClass(None, str), AClass(None, int)],
+            ),
+        )
+    )

--- a/tests/test_make_annotation.py
+++ b/tests/test_make_annotation.py
@@ -2,18 +2,23 @@ from typing import Optional, Union, List
 
 from graphotype.types import make_annotation, AClass, AOptional, NoneType, AUnion, AList
 
+NINT = AClass(None, int, origin=None)
+INT = AClass("int", int, origin=None)
+NSTR = AClass(None, str, origin=None)
+STR = AClass("str", str, origin=None)
+
 
 def test_make_annotation_simple():
-    assert make_annotation(None, str) == AClass(None, str)
+    assert make_annotation(None, str) == NSTR
     assert make_annotation(None, Optional[int]) == AOptional(
-        None, Union[int, NoneType], of_type=AClass(None, int)
+        None, Union[int, NoneType], of_type=NINT, origin=None
     )
 
 
 def test_make_annotation_simple_named():
-    assert make_annotation("str", str) == AClass("str", str)
+    assert make_annotation("str", str) == STR
     assert make_annotation("MaybeInt", Optional[int]) == AOptional(
-        "MaybeInt", Union[int, NoneType], of_type=AClass(None, int)
+        "MaybeInt", Union[int, NoneType], of_type=NINT, origin=None
     )
 
 
@@ -21,15 +26,16 @@ def test_make_annotation_unwraps_optional_and_list():
     """make_annotation will unwrap the brackets and preserve the 'raw' of whatever is inside
     your Optionals and Lists"""
     assert make_annotation("Optional[int]", Optional[int]) == AOptional(
-        "Optional[int]", Union[int, NoneType], of_type=AClass("int", int)
+        "Optional[int]", Union[int, NoneType], of_type=INT, origin=None
     )
     assert make_annotation("List[int]", List[int]) == AList(
-        "List[int]", List[int], of_type=AClass("int", int)
+        "List[int]", List[int], of_type=INT, origin=None
     )
     assert make_annotation("Optional[List[int]]", Optional[List[int]]) == AOptional(
         "Optional[List[int]]",
         Union[List[int], NoneType],
-        of_type=AList("List[int]", List[int], of_type=AClass("int", int)),
+        of_type=AList("List[int]", List[int], of_type=INT, origin=None),
+        origin=None,
     )
 
 
@@ -37,14 +43,14 @@ def test_make_annotation_union():
     """You can always call make_annotation on a Union, even though you
     might not be able to use it directly in a graphql type."""
     assert make_annotation(None, Union[str, int]) == AUnion(
-        None, Union[str, int], of_types=[AClass(None, str), AClass(None, int)]
+        None, Union[str, int], of_types=[NSTR, NINT], origin=None
     )
 
 
 def test_make_annotation_union_named():
     """The union name is preserved at the top level."""
     assert make_annotation("StrOrInt", Union[str, int]) == AUnion(
-        "StrOrInt", Union[str, int], of_types=[AClass(None, str), AClass(None, int)]
+        "StrOrInt", Union[str, int], of_types=[NSTR, NINT], origin=None
     )
 
 
@@ -53,22 +59,21 @@ def test_make_annotation_opt_union():
     assert make_annotation(None, Optional[Union[str, int]]) == AOptional(
         None,
         Optional[Union[str, int]],
-        of_type=AUnion(
-            None, Union[str, int], of_types=[AClass(None, str), AClass(None, int)]
-        ),
+        of_type=AUnion(None, Union[str, int], of_types=[NSTR, NINT], origin=None),
+        origin=None,
     )
 
 
 def test_make_annotation_opt_union_named():
     """make_annotation on optional named Union"""
-    assert make_annotation('Optional[StrOrInt]', Optional[Union[str, int]]) == AOptional(
-        'Optional[StrOrInt]',
+    assert make_annotation(
+        "Optional[StrOrInt]", Optional[Union[str, int]]
+    ) == AOptional(
+        "Optional[StrOrInt]",
         Optional[Union[str, int]],
-        of_type=AUnion(
-            'StrOrInt', Union[str, int], of_types=[AClass(None, str), AClass(None, int)]
-        ),
+        of_type=AUnion("StrOrInt", Union[str, int], of_types=[NSTR, NINT], origin=None),
+        origin=None,
     )
-
 
 
 def test_make_annotation_list_union_named():
@@ -78,9 +83,8 @@ def test_make_annotation_list_union_named():
             "List[StrOrInt]",
             List[Union[str, int]],
             of_type=AUnion(
-                "StrOrInt",
-                Union[str, int],
-                of_types=[AClass(None, str), AClass(None, int)],
+                "StrOrInt", Union[str, int], of_types=[NSTR, NINT], origin=None
             ),
+            origin=None,
         )
     )

--- a/tests/test_unions.py
+++ b/tests/test_unions.py
@@ -17,7 +17,7 @@ OptMyUnion = Optional[MyUnion]
 class Query(Object):
     requiredFoo: 'MyUnion' = Foo()
     requiredBar: 'MyUnion' = Bar()
-    optionalFoo: OptMyUnion = None
+    optionalFoo: 'OptMyUnion' = None
     optionalBar: Optional['MyUnion'] = None
 
 @pytest.fixture(scope='module')

--- a/tests/test_unions.py
+++ b/tests/test_unions.py
@@ -12,12 +12,10 @@ class Bar(Object):
     b: str = 'b'
 
 MyUnion = Union[Foo, Bar]
-OptMyUnion = Optional[MyUnion]
 
 class Query(Object):
     requiredFoo: 'MyUnion' = Foo()
     requiredBar: 'MyUnion' = Bar()
-    optionalFoo: 'OptMyUnion' = None
     optionalBar: Optional['MyUnion'] = None
 
 @pytest.fixture(scope='module')
@@ -28,7 +26,6 @@ def test_union(schema):
     result = graphql(schema, '''query {
         requiredFoo { ... F ... B }
         requiredBar { ... F ... B }
-        optionalFoo { ... F ... B }
         optionalBar { ... F ... B }
     }
     fragment F on Foo { i }
@@ -38,7 +35,6 @@ def test_union(schema):
     assert result.data == {
         'requiredFoo': { 'i': 1 },
         'requiredBar': { 'b': 'b' },
-        'optionalFoo': None,
         'optionalBar': None
     }
 

--- a/tests/test_unions_pep563.py
+++ b/tests/test_unions_pep563.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional, Union
 
 from graphql import graphql
@@ -15,10 +17,10 @@ MyUnion = Union[Foo, Bar]
 OptMyUnion = Optional[MyUnion]
 
 class Query(Object):
-    requiredFoo: 'MyUnion' = Foo()
-    requiredBar: 'MyUnion' = Bar()
+    requiredFoo: MyUnion = Foo()
+    requiredBar: MyUnion = Bar()
     optionalFoo: OptMyUnion = None
-    optionalBar: Optional['MyUnion'] = None
+    optionalBar: Optional[MyUnion] = None
 
 @pytest.fixture(scope='module')
 def schema():
@@ -44,7 +46,7 @@ def test_union(schema):
 
 def test_unnamed_union():
     class Query(Object):
-        requiredFoo: MyUnion
+        requiredFoo: Union[int, str]
 
     with pytest.raises(SchemaError) as e:
         make_schema(Query)

--- a/tests/test_unions_pep563.py
+++ b/tests/test_unions_pep563.py
@@ -14,12 +14,10 @@ class Bar(Object):
     b: str = 'b'
 
 MyUnion = Union[Foo, Bar]
-OptMyUnion = Optional[MyUnion]
 
 class Query(Object):
     requiredFoo: MyUnion = Foo()
     requiredBar: MyUnion = Bar()
-    optionalFoo: OptMyUnion = None
     optionalBar: Optional[MyUnion] = None
 
 @pytest.fixture(scope='module')
@@ -30,7 +28,6 @@ def test_union(schema):
     result = graphql(schema, '''query {
         requiredFoo { ... F ... B }
         requiredBar { ... F ... B }
-        optionalFoo { ... F ... B }
         optionalBar { ... F ... B }
     }
     fragment F on Foo { i }
@@ -40,7 +37,6 @@ def test_union(schema):
     assert result.data == {
         'requiredFoo': { 'i': 1 },
         'requiredBar': { 'b': 'b' },
-        'optionalFoo': None,
         'optionalBar': None
     }
 

--- a/tests/test_unwrap_outer.py
+++ b/tests/test_unwrap_outer.py
@@ -1,0 +1,42 @@
+from typing import List, Optional, Union
+
+import pytest
+
+from graphotype.types import _unwrap_outer, UnwrapException
+
+
+def test_unwrap_outer_str_basics():
+    assert _unwrap_outer("Optional[int]") == 'int'
+    assert _unwrap_outer("List[int]") == 'int'
+    assert _unwrap_outer("Optional[List[int]]") == 'List[int]'
+    assert _unwrap_outer("List[Optional[int]]") == 'Optional[int]'
+
+
+def test_unwrap_outer_str_strips_whitespace():
+    assert _unwrap_outer("List[  int   ]") == 'int'
+    assert _unwrap_outer(" List [int] ") == 'int'
+    assert _unwrap_outer("\nList [int\n\t] ") == 'int'
+    assert _unwrap_outer(_unwrap_outer("\nList[  Optional  [    int\n\t   ] ] ")) == 'int'
+
+
+def test_unwrap_outer_evald_types():
+    assert _unwrap_outer(List[int]) == int
+    assert _unwrap_outer(Optional[int]) == int
+    assert _unwrap_outer(List[Optional[int]]) == Optional[int]
+
+    assert _unwrap_outer(List['int']) == 'int'
+    assert _unwrap_outer(Optional['int']) == 'int'
+    assert _unwrap_outer(List['Optional[int]']) == 'Optional[int]'
+    assert _unwrap_outer(List[Optional['int']]) == Optional['int']
+
+
+def test_unwrap_around_union():
+    MyUnion = Union[str, int]
+    assert _unwrap_outer(List[MyUnion]) == MyUnion
+    assert _unwrap_outer(List['MyUnion']) == 'MyUnion'
+
+
+def test_cant_unwrap_union_directly():
+    MyUnion = Union[str, int]
+    with pytest.raises(UnwrapException):
+        _unwrap_outer(MyUnion)


### PR DESCRIPTION
- Preserve and recursively transform the raw strings during recursive make_annotation
- PEP563 gives us names for everything inside type annotations -- we now work better 
  with PEP563 enabled
- However, Unions don't work perfectly yet. The unittests show the failures.
  Either we need to refuse to accept the construct in those tests, or we need
  to go back to the system where a union ever being mentioned in a type
  annotation causes us to look it up in the typemap as before.

Do before merging:
- [x] set up 'origin' correctly in all cases
- [x] fix tests or delete erroneous tests